### PR TITLE
Itertools. Much Itertools. Itertools and zip.

### DIFF
--- a/PyLD.py
+++ b/PyLD.py
@@ -144,7 +144,7 @@ class LD(object):
         
         get_genotype = population.get
         results = []
-        for rsID_1, rsID_2 in itertools.combinations(self.list_of_rsIDs):
+        for rsID_1, rsID_2 in itertools.combinations(self.list_of_rsIDs, 2):
             # Genotypes
             genotype1 = get_genotype(population, rsID_1)
             genotype2 = get_genotype(population, rsID_2)

--- a/PyLD.py
+++ b/PyLD.py
@@ -1,90 +1,52 @@
+
 import csv
+import itertools
+
 import pandas as pd
 
-
 def get_dict_of_genotypes(file_path):
-
-    column_names = []
-
-    with open(file_path, 'r') as f:
-        for line in f:
-            # Strip whitespace from the line
-            line = line.strip()
-            if line.startswith("##"):
-                # Skip header lines that start with "##"
-                continue
-            # Store column names if the line starts with '#'
-            elif line.startswith("#"):
-                column_names = line.split("\t")
-            else:
-                break
-
-    # Read the VCF file again and create a df excluding header lines
-    data = []
-    with open(file_path, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if not line.startswith("#"):
-                # Split the line by tabs and append the data to the list
-                data.append(line.split("\t"))
-
-    # Create a DataFrame using column names and data
-    df = pd.DataFrame(data, columns=column_names)
-
-    filtered_df = df[['ID'] + [col for col in df.columns if col.startswith('HG')]]
-
-    result_dict = {}
-
-    for index, row in filtered_df.iterrows():
-            # Extract the ID from the current row
-        id_value = row['ID']
-        # Extract the values from the remaining columns
-        values = row.drop('ID').tolist()
-        # Add the ID and values to the dictionary
-        result_dict[id_value] = values
-        
-    return result_dict
-
-
-
-def get_genotype(population_dictionary, rsID):
-    genotype_list = population_dictionary[rsID]
-    return genotype_list
+    with open(file_path) as vcf_file:
+        # Skip metadata:
+        vcf_lines = itertools.dropwhile(lambda row: row.startswith('##'), vcf_file)
+        # According to the spec (https://samtools.github.io/hts-specs/VCFv4.2.pdf)
+        # the next line should be the header:
+        columns = vcf_lines.__next__().strip().lstrip('#').split('\t')
+        # What remains of vcf_lines should now be the data:
+        vcf_data = map(lambda row: row.strip().split('\t'), vcf_lines)
+        # Pandas is happy to consume the iterable:
+        vcf_df = pd.DataFrame(vcf_data, columns=columns)
+        # Columns of interest start with 'HG', index by 'ID':
+        gene_columns = list(filter(lambda col: col.startswith('HG'), columns))
+        gene_df = vcf_df.set_index('ID')[gene_columns]
+        # DataFrame.to_dict('index') returns a dict of dicts.
+        # Need the values of the inner dicts as lists.
+        return {k: list(v.values()) for k, v in gene_df.to_dict('index').items()}
     
+def pipe_split(gtype):
+    return gtype.split('|')
 
 def determine_haplotype(genotype_list_1, genotype_list_2):
     '''Function compares alleles of each individual and determines their haplotype
     '''
-    result = []
-    for i in range(len(genotype_list_1)):
-        genotype1 = genotype_list_1[i].split("|")
-        genotype2 = genotype_list_2[i].split("|")
-        gt1 = int(genotype1[0])
-        gt2 = int(genotype2[0])
-        gt3 = int(genotype1[1])
-        gt4 = int(genotype2[1])
-        if gt1 == 0 and gt2 == 0:
-            result.append("00")
-        elif gt1 == 0 and gt2 == 1:
-            result.append("01")
-        elif gt1 == 1 and gt2 == 0:
-            result.append("10")
-        elif gt1 == 1 and gt2 == 1:
-            result.append("11")
-        else:
-            result.append("N/A")
-        if gt3 == 0 and gt4 == 0:
-            result.append("00")
-        elif gt3 == 0 and gt4 == 1:
-            result.append("01")
-        elif gt3 == 1 and gt4 == 0:
-            result.append("10")
-        elif gt3 == 1 and gt4 == 1:
-            result.append("11")
-        else:
-            result.append("N/A")
-    return result
-    
+
+    # "genotypes" contains pairs of tuples from each list.
+    genotypes = zip(
+        map(pipe_split, genotype_list_1),
+        map(pipe_split, genotype_list_2)
+    )
+    '''
+    zip(*iterable) and itertools are our friends: (GRG)
+        eg = [(1 ,2), (3, 4)]
+        list(zip(*eg))
+        [(1, 3), (2, 4)]
+    '''
+    results = (''.join(gt)
+        for gt in itertools.chain.from_iterable(
+            itertools.starmap(zip, genotypes)
+        )
+    )    
+    valid = ('00', '01', '10', '11')
+    return [res if res in valid else 'N/A' for res in results]    
 
 def count_haplotypes(compare_genotypes):
     '''Function counts how many of each haplotype exist
@@ -94,12 +56,16 @@ def count_haplotypes(compare_genotypes):
     11 is Pa Pb alleles
     This is only possible because the vcf files I used had phased data.
     '''
-    count_dict = {'00': 0, '01': 0, '10': 0, '11': 0}
-    for genotype in compare_genotypes:
-        count_dict[genotype] += 1
-    return count_dict
     
-
+    '''
+     "itertools.groupby" makes this a "one-liner", if that's a *good*
+     thing. *Might* be faster than "+=". Don't forget to sort. -GRG
+    '''
+    return {
+        hap: len(list(group)) for hap, group in itertools.groupby(
+            sorted(compare_genotypes))
+    }
+    
 def count_PA_PB_PAB(haplotype_counts):
     '''
     Function obtains the PA, PB, PAB allele frequencies needed for r^2 and D' calculations
@@ -107,14 +73,18 @@ def count_PA_PB_PAB(haplotype_counts):
     For the toy population we used had 100 individuals, so 200 alleles
     '''
     count_dict = {'PA': 0, 'PB': 0, 'PAB': 0}
-    total = 200 # this will need to become a count of how many HG individuals there are 
-    count_dict['PA'] = (haplotype_counts['00']+haplotype_counts['01'])/total
-    count_dict['PB'] = (haplotype_counts['00']+haplotype_counts['10'])/total
-    count_dict['PAB'] = (haplotype_counts['00'])/total
+    
+    '''
+    "sum" is a built-in, if all the values in the dict are numeric,
+    All Shall Be Well. No need to hard-code:
+    '''
+    total = sum(haplotype_counts.values()) 
+    count_dict['PA'] = (haplotype_counts['00'] + haplotype_counts['01']) / total
+    count_dict['PB'] = (haplotype_counts['00'] + haplotype_counts['10']) / total
+    count_dict['PAB'] = (haplotype_counts['00']) / total
 
     return count_dict
     
-
 def calculate_D(count_dict):
     '''
     Function that calculates D
@@ -126,7 +96,6 @@ def calculate_D(count_dict):
     D = PAB - (PA * PB)
     return D    
     
-
 def calculate_r_squared(D, count_dict):
     '''
     Function calculates the r^2, which is a measure of D. It measures the correlation.
@@ -140,7 +109,6 @@ def calculate_r_squared(D, count_dict):
     
     return r_squared    
     
-
 def calculate_D_prime(D, count_dict):
     '''
     Function for calculating D' measurement of Linkage Disequilibrium. 
@@ -160,60 +128,63 @@ def calculate_D_prime(D, count_dict):
 
     return D_prime
 
-
-
-class LD:
+class LD(object):
     def __init__(self, file_path, list_of_rsIDs):
         self.file_path = file_path
         self.list_of_rsIDs = list_of_rsIDs
-        self.results = []
 
     def calculate_LD_measures(self): 
         population = get_dict_of_genotypes(self.file_path)
 
-        for i in range(len(self.list_of_rsIDs)):
-            for j in range(i+1, len(self.list_of_rsIDs)):
-                rsID_1 = self.list_of_rsIDs[i]
-                rsID_2 = self.list_of_rsIDs[j]
-                # Genotypes
-                genotype1 = get_genotype(population, rsID_1)
-                genotype2 = get_genotype(population, rsID_2)
-                # Haplotypes
-                haplotypes = determine_haplotype(genotype1, genotype2)
-                haplotypes_count = count_haplotypes(haplotypes)
-                # Loci Frequencies
-                loci_frequencies = count_PA_PB_PAB(haplotypes_count)
-                # LD measures 
-                D = calculate_D(loci_frequencies)
-                r2 = calculate_r_squared(D, loci_frequencies)
-                Dprime = calculate_D_prime(D, loci_frequencies)
-                # Dictionary of result for one pair of rsIDs
-                result = {'rsID_1': rsID_1, 'rsID_2': rsID_2,
-                    'haplotypes': haplotypes_count,
-                    'pA':  loci_frequencies['PA'], 
-                    'pB': loci_frequencies['PB'], 
-                    'pAB': loci_frequencies['PAB'],
-                    'D': D,
-                    'r^2': r2, 
-                    'Dprime': Dprime}
-                # List of final results
-                self.results.append(result)
+        '''Do away with one level of indentation with "combinations".
+        Unless you *really* want to manipulate indices,
+        some_list[i] for i in range(len(some_list)) is a bit cringe...
+        -GRG
+        '''
+        
+        get_genotype = population.get
+        results = []
+        for rsID_1, rsID_2 in itertools.combinations(self.list_of_rsIDs):
+            # Genotypes
+            genotype1 = get_genotype(population, rsID_1)
+            genotype2 = get_genotype(population, rsID_2)
+            # Haplotypes
+            haplotypes = determine_haplotype(genotype1, genotype2)
+            haplotypes_count = count_haplotypes(haplotypes)
+            # Loci Frequencies
+            loci_frequencies = count_PA_PB_PAB(haplotypes_count)
+            # LD measures 
+            D = calculate_D(loci_frequencies)
+            r2 = calculate_r_squared(D, loci_frequencies)
+            Dprime = calculate_D_prime(D, loci_frequencies)
+            # Dictionary of result for one pair of rsIDs
+            result = {'rsID_1': rsID_1, 'rsID_2': rsID_2,
+                'haplotypes': haplotypes_count,
+                'pA':  loci_frequencies['PA'], 
+                'pB': loci_frequencies['PB'], 
+                'pAB': loci_frequencies['PAB'],
+                'D': D,
+                'r^2': r2, 
+                'Dprime': Dprime}
+            # List of final results
+            results.append(result)
 
-        return self.results
+        return results
     
     def save_results(self, output_file_path):
         results = self.calculate_LD_measures()
         with open(output_file_path, 'w', newline='', encoding="utf-8") as f:
-            writer = csv.writer(f, delimiter='\t')
-            writer.writerow(results[0].keys())
+            # DictWriters are a thing -GRG.
+            writer = csv.DictWriter(
+                f, fieldnames=results[0].keys(), delimiter='\t'
+            )
+            writer.writeheader()
             for row in results:
-                writer.writerow(row.values())
+                writer.writerow(row)
         
 
 #test_list = ['rs1050979', 'rs34941730', 'rs116763857']
-#test = LD('/Users/martadelfino/PyLD/toy_data.vcf', test_list)
+#test = LD('toy_data.vcf', test_list)
 #print(test.calculate_LD_measures())
-
-
-#test.save_results('/Users/martadelfino/PyLD/test_output.csv')
+#test.save_results('test_output.tsv')
 


### PR DESCRIPTION
How much fun can we have with [Itertools](https://docs.python.org/3/library/itertools.html)?

`get_dict_of_genotypes` becomes rather less verbose with `map` (or `filter`) and `iterools.takewhile`.
Pandas' `set_index` and `to_dict` can do much of the work that was being done by `iterrows`, which should
mostly be [avoided](https://realpython.com/pandas-iterate-over-rows/). Vectorize All The Things.

`determine_haplotype` needn't turn strings to ints and back again, if the double usage of `zip` isn't too cryptic.

`itertools.groupby` can do all the work in `count_haplotypes`.

Iterating over the things you're interested in, rather than indices in ranges will always be more readable.

The calculations are all pretty tidy.

On branch review_grg
	modified:   PyLD.py